### PR TITLE
Power Status Implementation with psutil

### DIFF
--- a/game/components/window_clock.py
+++ b/game/components/window_clock.py
@@ -53,9 +53,9 @@ class WindowClock:
             return "battery_charging"
         elif percent <= 5.0:
             return "battery_empty"
-        elif percent <= 20.0:
+        elif percent <= 33.3:
             return "battery_low"
-        elif percent <= 50.0:
+        elif percent <= 66.7:
             return "battery_half"
         else:
             return "battery_full"

--- a/game/components/window_clock.py
+++ b/game/components/window_clock.py
@@ -65,8 +65,7 @@ class WindowClock:
         if now - self.last_battery_update < 5:
             return
 
-        percent = self.battery.get_battery_percentage()
-        charging = self.battery.is_charging()
+        percent, charging = self.battery.get_battery_info()
         icon_key = self.select_icon_key(percent, charging)
 
         icon = self.battery_icons.get(icon_key)


### PR DESCRIPTION
I have implemented changes for power status that are ready for review.

These changes do not affect RPI systems without psutil installed, but change the default behavior of non-RPI systems without psutil to show an empty battery instead of a full one, as this communicates better to the user that the battery status is non-functional. RPI systems with psutil installed will use psutil.

With these changes, my desktop shows "empty" battery without psutil, and "charging" status with psutil installed, as it is has no battery and is plugged in.

My RG351P changes to "charging" when plugged in, and to a battery status when unplugged, and the battery status changes depending on the charge level.

My Macbook Pro laptop shows "empty" battery without psutil, and after installing psutil, changes to "charging" when plugged in, and to a battery status when unplugged, and the battery status changes depending on the charge level.